### PR TITLE
Add OAuth2 Support #15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 - pip install -U tox-travis
 - pip install coverage
 - pip install requests
+- pip install tinydb
 language: python
 python:
 - pypy3

--- a/Pipfile
+++ b/Pipfile
@@ -10,15 +10,12 @@ watchdog = ">=\"0.8.3\""
 tox = ">=\"2.3.1\""
 coverage = ">=\"4.1\""
 Sphinx = ">=\"1.4.8\""
-cryptography = ">=\"1.7\""
 PyYAML = ">=\"3.11\""
 pytest = ">=\"2.9.2\""
 pytest-runner = ">=\"2.11.1\""
 
 [packages]
 requests = "*"
-pyOpenSSL = "*"
-requests-oauthlib = "*"
 tinydb = "*"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -1,30 +1,25 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
 [dev-packages]
-
 bumpversion = ">=\"0.5.3\""
 watchdog = ">=\"0.8.3\""
 "flake8" = ">=\"2.6.0\""
 tox = ">=\"2.3.1\""
 coverage = ">=\"4.1\""
-sphinx = ">=\"1.4.8\""
+Sphinx = ">=\"1.4.8\""
 cryptography = ">=\"1.7\""
-pyyaml = ">=\"3.11\""
+PyYAML = ">=\"3.11\""
 pytest = ">=\"2.9.2\""
 pytest-runner = ">=\"2.11.1\""
 
-
 [packages]
-
 requests = "*"
-pyopenssl = "*"
+pyOpenSSL = "*"
 requests-oauthlib = "*"
-
+tinydb = "*"
 
 [requires]
-
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a14270ed362d6a6a54878f7d558d20b7c16c1c11ad271eb4d41a6d761aaad4b1"
+            "sha256": "3724dcc6a751f27f189c6e882cbb8e1768d0f338182490d8813b0a7208a370b3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,52 +16,12 @@
         ]
     },
     "default": {
-        "asn1crypto": {
-            "hashes": [
-                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
-                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
-            ],
-            "version": "==0.24.0"
-        },
         "certifi": {
             "hashes": [
                 "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
                 "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
             "version": "==2018.4.16"
-        },
-        "cffi": {
-            "hashes": [
-                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
-                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
-                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
-                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
-                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
-                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
-                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
-                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
-                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
-                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
-                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
-                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
-                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
-                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
-                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
-                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
-                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
-                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
-                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
-                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
-                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
-                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
-                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
-                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
-                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
-                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
-                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
-            ],
-            "markers": "platform_python_implementation != 'PyPy'",
-            "version": "==1.11.5"
         },
         "chardet": {
             "hashes": [
@@ -70,73 +30,12 @@
             ],
             "version": "==3.0.4"
         },
-        "cryptography": {
-            "hashes": [
-                "sha256:3f3b65d5a16e6b52fba63dc860b62ca9832f51f1a2ae5083c78b6840275f12dd",
-                "sha256:551a3abfe0c8c6833df4192a63371aa2ff43afd8f570ed345d31f251d78e7e04",
-                "sha256:5cb990056b7cadcca26813311187ad751ea644712022a3976443691168781b6f",
-                "sha256:60bda7f12ecb828358be53095fc9c6edda7de8f1ef571f96c00b2363643fa3cd",
-                "sha256:6fef51ec447fe9f8351894024e94736862900d3a9aa2961528e602eb65c92bdb",
-                "sha256:77d0ad229d47a6e0272d00f6bf8ac06ce14715a9fd02c9a97f5a2869aab3ccb2",
-                "sha256:808fe471b1a6b777f026f7dc7bd9a4959da4bfab64972f2bbe91e22527c1c037",
-                "sha256:9b62fb4d18529c84b961efd9187fecbb48e89aa1a0f9f4161c61b7fc42a101bd",
-                "sha256:9e5bed45ec6b4f828866ac6a6bedf08388ffcfa68abe9e94b34bb40977aba531",
-                "sha256:9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63",
-                "sha256:abd070b5849ed64e6d349199bef955ee0ad99aefbad792f0c587f8effa681a5e",
-                "sha256:ba6a774749b6e510cffc2fb98535f717e0e5fd91c7c99a61d223293df79ab351",
-                "sha256:c332118647f084c983c6a3e1dba0f3bcb051f69d12baccac68db8d62d177eb8a",
-                "sha256:d6f46e862ee36df81e6342c2177ba84e70f722d9dc9c6c394f9f1f434c4a5563",
-                "sha256:db6013746f73bf8edd9c3d1d3f94db635b9422f503db3fc5ef105233d4c011ab",
-                "sha256:f57008eaff597c69cf692c3518f6d4800f0309253bb138b526a37fe9ef0c7471",
-                "sha256:f6c821ac253c19f2ad4c8691633ae1d1a17f120d5b01ea1d256d7b602bc59887"
-            ],
-            "version": "==2.2.2"
-        },
-        "enum34": {
-            "hashes": [
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
-            ],
-            "markers": "python_version < '3'",
-            "version": "==1.1.6"
-        },
         "idna": {
             "hashes": [
                 "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
                 "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
             ],
             "version": "==2.6"
-        },
-        "ipaddress": {
-            "hashes": [
-                "sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794",
-                "sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
-            ],
-            "markers": "python_version < '3'",
-            "version": "==1.0.22"
-        },
-        "oauthlib": {
-            "hashes": [
-                "sha256:09d438bcac8f004ae348e721e9d8a7792a9e23cd574634e973173344046287f5",
-                "sha256:909665297635fa11fe9914c146d875f2ed41c8c2d78e21a529dd71c0ba756508"
-            ],
-            "version": "==2.0.7"
-        },
-        "pycparser": {
-            "hashes": [
-                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
-            ],
-            "version": "==2.18"
-        },
-        "pyopenssl": {
-            "hashes": [
-                "sha256:07a2de1a54de07448732a81e38a55df7da109b2f47f599f8bb35b0cbec69d4bd",
-                "sha256:2c10cfba46a52c0b0950118981d61e72c1e5b1aac451ca1bc77de1a679456773"
-            ],
-            "index": "pypi",
-            "version": "==17.5.0"
         },
         "requests": {
             "hashes": [
@@ -145,21 +44,6 @@
             ],
             "index": "pypi",
             "version": "==2.18.4"
-        },
-        "requests-oauthlib": {
-            "hashes": [
-                "sha256:50a8ae2ce8273e384895972b56193c7409601a66d4975774c60c2aed869639ca",
-                "sha256:883ac416757eada6d3d07054ec7092ac21c7f35cb1d2cf82faf205637081f468"
-            ],
-            "index": "pypi",
-            "version": "==0.8.0"
-        },
-        "six": {
-            "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
-            ],
-            "version": "==1.11.0"
         },
         "tinydb": {
             "hashes": [
@@ -192,13 +76,6 @@
             ],
             "version": "==0.26.2"
         },
-        "asn1crypto": {
-            "hashes": [
-                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
-                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
-            ],
-            "version": "==0.24.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
@@ -227,39 +104,6 @@
                 "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
             "version": "==2018.4.16"
-        },
-        "cffi": {
-            "hashes": [
-                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
-                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
-                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
-                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
-                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
-                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
-                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
-                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
-                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
-                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
-                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
-                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
-                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
-                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
-                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
-                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
-                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
-                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
-                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
-                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
-                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
-                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
-                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
-                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
-                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
-                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
-                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
-            ],
-            "markers": "platform_python_implementation != 'PyPy'",
-            "version": "==1.11.5"
         },
         "chardet": {
             "hashes": [
@@ -317,28 +161,6 @@
             "index": "pypi",
             "version": "==4.5.1"
         },
-        "cryptography": {
-            "hashes": [
-                "sha256:3f3b65d5a16e6b52fba63dc860b62ca9832f51f1a2ae5083c78b6840275f12dd",
-                "sha256:551a3abfe0c8c6833df4192a63371aa2ff43afd8f570ed345d31f251d78e7e04",
-                "sha256:5cb990056b7cadcca26813311187ad751ea644712022a3976443691168781b6f",
-                "sha256:60bda7f12ecb828358be53095fc9c6edda7de8f1ef571f96c00b2363643fa3cd",
-                "sha256:6fef51ec447fe9f8351894024e94736862900d3a9aa2961528e602eb65c92bdb",
-                "sha256:77d0ad229d47a6e0272d00f6bf8ac06ce14715a9fd02c9a97f5a2869aab3ccb2",
-                "sha256:808fe471b1a6b777f026f7dc7bd9a4959da4bfab64972f2bbe91e22527c1c037",
-                "sha256:9b62fb4d18529c84b961efd9187fecbb48e89aa1a0f9f4161c61b7fc42a101bd",
-                "sha256:9e5bed45ec6b4f828866ac6a6bedf08388ffcfa68abe9e94b34bb40977aba531",
-                "sha256:9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63",
-                "sha256:abd070b5849ed64e6d349199bef955ee0ad99aefbad792f0c587f8effa681a5e",
-                "sha256:ba6a774749b6e510cffc2fb98535f717e0e5fd91c7c99a61d223293df79ab351",
-                "sha256:c332118647f084c983c6a3e1dba0f3bcb051f69d12baccac68db8d62d177eb8a",
-                "sha256:d6f46e862ee36df81e6342c2177ba84e70f722d9dc9c6c394f9f1f434c4a5563",
-                "sha256:db6013746f73bf8edd9c3d1d3f94db635b9422f503db3fc5ef105233d4c011ab",
-                "sha256:f57008eaff597c69cf692c3518f6d4800f0309253bb138b526a37fe9ef0c7471",
-                "sha256:f6c821ac253c19f2ad4c8691633ae1d1a17f120d5b01ea1d256d7b602bc59887"
-            ],
-            "version": "==2.2.2"
-        },
         "docutils": {
             "hashes": [
                 "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
@@ -354,7 +176,7 @@
                 "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
                 "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
             ],
-            "markers": "python_version < '3'",
+            "markers": "python_version < '3.4'",
             "version": "==1.1.6"
         },
         "flake8": {
@@ -386,14 +208,6 @@
                 "sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315"
             ],
             "version": "==1.0.0"
-        },
-        "ipaddress": {
-            "hashes": [
-                "sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794",
-                "sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
-            ],
-            "markers": "python_version < '3'",
-            "version": "==1.0.22"
         },
         "jinja2": {
             "hashes": [
@@ -459,12 +273,6 @@
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],
             "version": "==2.3.1"
-        },
-        "pycparser": {
-            "hashes": [
-                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
-            ],
-            "version": "==2.18"
         },
         "pyflakes": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8e6a509aeb35047d107a9c1f1aedde3884a4a7e421218356a25164febb7b0862"
+            "sha256": "a14270ed362d6a6a54878f7d558d20b7c16c1c11ad271eb4d41a6d761aaad4b1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,10 +25,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
-                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
-            "version": "==2018.1.18"
+            "version": "==2018.4.16"
         },
         "cffi": {
             "hashes": [
@@ -92,12 +92,30 @@
             ],
             "version": "==2.2.2"
         },
+        "enum34": {
+            "hashes": [
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+            ],
+            "markers": "python_version < '3'",
+            "version": "==1.1.6"
+        },
         "idna": {
             "hashes": [
                 "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
                 "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
             ],
             "version": "==2.6"
+        },
+        "ipaddress": {
+            "hashes": [
+                "sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794",
+                "sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
+            ],
+            "markers": "python_version < '3'",
+            "version": "==1.0.22"
         },
         "oauthlib": {
             "hashes": [
@@ -142,6 +160,14 @@
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
+        },
+        "tinydb": {
+            "hashes": [
+                "sha256:67b3b302fc86e0139db545d5abd65bf0e1dadaecee63bd1ff3fe2169810d5387",
+                "sha256:e7d939c52710ee4354bb619b9bed05ae6192645f1520f13d8fcf4f06b5590e02"
+            ],
+            "index": "pypi",
+            "version": "==3.9.0"
         },
         "urllib3": {
             "hashes": [
@@ -197,10 +223,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
-                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
-            "version": "==2018.1.18"
+            "version": "==2018.4.16"
         },
         "cffi": {
             "hashes": [
@@ -241,6 +267,13 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "configparser": {
+            "hashes": [
+                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.5.0"
         },
         "coverage": {
             "hashes": [
@@ -314,6 +347,16 @@
             ],
             "version": "==0.14"
         },
+        "enum34": {
+            "hashes": [
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+            ],
+            "markers": "python_version < '3'",
+            "version": "==1.1.6"
+        },
         "flake8": {
             "hashes": [
                 "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
@@ -321,6 +364,14 @@
             ],
             "index": "pypi",
             "version": "==3.5.0"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "markers": "python_version < '3.0'",
+            "version": "==1.0.2"
         },
         "idna": {
             "hashes": [
@@ -335,6 +386,14 @@
                 "sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315"
             ],
             "version": "==1.0.0"
+        },
+        "ipaddress": {
+            "hashes": [
+                "sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794",
+                "sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
+            ],
+            "markers": "python_version < '3'",
+            "version": "==1.0.22"
         },
         "jinja2": {
             "hashes": [
@@ -379,7 +438,9 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },
@@ -392,6 +453,8 @@
         },
         "pycodestyle": {
             "hashes": [
+                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
+                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],
@@ -431,11 +494,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c",
-                "sha256:fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
+                "sha256:54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8",
+                "sha256:829230122facf05a5f81a6d4dfe6454a04978ea3746853b2b84567ecf8e5c526"
             ],
             "index": "pypi",
-            "version": "==3.5.0"
+            "version": "==3.5.1"
         },
         "pytest-runner": {
             "hashes": [
@@ -447,17 +510,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
-                "sha256:3a47ff71597f821cd84a162e71593004286e5be07a340fd462f0d33a760782b5",
-                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0",
-                "sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d",
-                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
-                "sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef",
-                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
-                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
-                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda"
+                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
+                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
             ],
-            "version": "==2018.3"
+            "version": "==2018.4"
         },
         "pyyaml": {
             "hashes": [
@@ -503,11 +559,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:5a1c9a0fec678c24b9a2f5afba240c04668edb7f45c67ce2ed008996b3f21ae2",
-                "sha256:7a606d77618a753adb79e13605166e3cf6a0e5678526e044236fc1ac43650910"
+                "sha256:2e7ad92e96eff1b2006cf9f0cdb2743dacbae63755458594e9e8238b0c3dc60b",
+                "sha256:e9b1a75a3eae05dded19c80eb17325be675e0698975baae976df603b6ed1eb10"
             ],
             "index": "pypi",
-            "version": "==1.7.2"
+            "version": "==1.7.4"
         },
         "sphinxcontrib-websupport": {
             "hashes": [
@@ -518,11 +574,20 @@
         },
         "tox": {
             "hashes": [
-                "sha256:1ff75c8f8890046f42c8d49a994b11a57c3d262048b815e1c19970028eb44e53",
-                "sha256:9536130d8f47b06460325e5d8b908268a5bf3574a74e32437cf9686d13162215"
+                "sha256:96efa09710a3daeeb845561ebbe1497641d9cef2ee0aea30db6969058b2bda2f",
+                "sha256:9ee7de958a43806402a38c0d2aa07fa8553f4d2c20a15b140e9f771c2afeade0"
             ],
             "index": "pypi",
-            "version": "==3.0.0rc4"
+            "version": "==3.0.0"
+        },
+        "typing": {
+            "hashes": [
+                "sha256:3a887b021a77b292e151afb75323dea88a7bc1b3dfa92176cff8e44c8b68bddf",
+                "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8",
+                "sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==3.6.4"
         },
         "urllib3": {
             "hashes": [

--- a/pancloud/__init__.py
+++ b/pancloud/__init__.py
@@ -8,6 +8,7 @@ from .exceptions import PanCloudError, HTTPError, \
     UnexpectedKwargsError, RequiredKwargsError
 from .httpclient import HTTPClient
 from .logging import LoggingService
+from .credentials import Credentials
 
 __author__ = 'Palo Alto Networks'
 __version__ = '1.0.3'

--- a/pancloud/credentials.py
+++ b/pancloud/credentials.py
@@ -1,0 +1,361 @@
+# -*- coding: utf-8 -*-
+
+"""Access, store and retrieve credentials from providers."""
+from __future__ import absolute_import
+
+import os
+import uuid
+from collections import namedtuple
+from threading import Lock, RLock
+
+import requests
+from tinydb import TinyDB, Query
+
+from .exceptions import UnexpectedKwargsError, PanCloudError
+
+# Constants
+TOKEN_URL = 'https://api.paloaltonetworks.com/api/oauth2/RequestToken'
+REVOKE_URL = 'https://api.paloaltonetworks.com/api/oauth2/RevokeToken'
+BASE_URL = 'https://identity.paloaltonetworks.com/as/authorization.oauth2'
+
+ReadOnlyCredentials = namedtuple(
+    'ReadOnlyCredentials',
+    ['access_token', 'client_id', 'client_secret', 'refresh_token']
+)
+
+
+class Credentials(object):
+    """An Application Framework credentials object."""
+
+    def __init__(self, auth_base_url=None, client_id=None, client_secret=None,
+                 instance_id=None, profile=None, redirect_uri=None, region=None,
+                 refresh_token=None, scope=None, token_url=None,
+                 token_revoke_url=None, **kwargs):
+        """Persist Session() and credentials attributes.
+
+        Built on top of the ``Requests`` library, ``Credentials`` is an
+        abstraction layer for storing, resolving and retrieving
+        credentials needed for interacting with the Application
+        Framework.
+
+        ``Credentials`` resolves credentials in the following order:
+
+            1) Service object
+            2) HTTPClient session
+            3) Environment variables
+            4) Credentials file
+
+        Args:
+            auth_base_url (str): IdP base authorization URL. Default to ``None``.
+            client_id (str): OAuth2 client ID. Defaults to ``None``.
+            client_secret (str): OAuth2 client secret. Defaults to ``None``.
+            instance_id (str): Instance ID. Defaults to ``None``.
+            profile (str): Credentials profile. Defaults to ``'default'``.
+            redirect_uri (str): Redirect URI. Defaults to ``None``.
+            region (str): Region. Defaults to ``None``.
+            refresh_token (str): OAuth2 refresh token. Defaults to ``None``.
+            scope (str): OAuth2 scope. Defaults to ``None``.
+            token_url (str): Refresh URL. Defaults to ``None``.
+            token_revoke_url (str): Revoke URL. Defaults to ``None``.
+            **kwargs: Supported :class:`~requests.Session` parameters.
+
+        """
+        self.access_token_ = None
+        self.auth_base_url = auth_base_url or BASE_URL
+        self.client_id_ = client_id
+        self.client_secret_ = client_secret
+        self.db_lock = RLock()
+        self.environ = os.environ
+        self.instance_id = instance_id
+        self.path = os.path.join(os.path.expanduser('~'), '.config',
+                                 'pancloud', 'credentials.json')
+        self.profile = profile or 'default'
+        self.redirect_uri = redirect_uri
+        self.region = region
+        self.refresh_token_ = refresh_token
+        self.scope = scope
+        self.state = uuid.uuid4()
+        self.token_lock = Lock()
+        self.token_url = token_url or TOKEN_URL
+        self.token_revoke_url = token_revoke_url or REVOKE_URL
+        if not os.path.exists(os.path.dirname(self.path)):
+            os.mkdir(os.path.dirname(self.path))
+        self.db = TinyDB(self.path, sort_keys=True, indent=4,
+                         default_table='profiles')
+        self.query = Query()
+        with requests.Session() as self.session:
+            self.session.auth = kwargs.pop('auth', self.session.auth)
+            self.session.cert = kwargs.pop('cert', self.session.cert)
+            self.session.cookies = kwargs.pop('cookies',
+                                              self.session.cookies)
+            self.session.headers = kwargs.pop('headers',
+                                              self.session.headers)
+            self.session.params = kwargs.pop('params',
+                                             self.session.params)
+            self.session.proxies = kwargs.pop('proxies',
+                                              self.session.proxies)
+            self.session.stream = kwargs.pop('stream',
+                                             self.session.stream)
+            self.session.trust_env = kwargs.pop('trust_env',
+                                                self.session.trust_env)
+            self.session.verify = kwargs.pop('verify',
+                                             self.session.verify)
+            if len(kwargs) > 0:
+                raise UnexpectedKwargsError(kwargs)
+
+    @property
+    def access_token(self):
+        return self.access_token_
+
+    @property
+    def client_id(self):
+        return self.client_id_ or \
+               self._resolve_credential('client_id')
+
+    @property
+    def client_secret(self):
+        return self.client_secret_ or \
+               self._resolve_credential('client_secret')
+
+    @property
+    def refresh_token(self):
+        return self.refresh_token_ or \
+               self._resolve_credential('refresh_token')
+
+    def _fetch_credential(self, credential):
+        """Fetch credential from credentials file.
+
+        Args:
+            credential (str): Credential to fetch.
+
+        Returns:
+            str, None: Fetched credential or ``None``.
+
+        """
+        q = self.db.search(self.query.profile == self.profile)
+        try:
+            return q[0].get(credential, '')
+        except (AttributeError, ValueError, IndexError):
+            return
+
+    def _resolve_credential(self, credential):
+        """Resolve credential from environ or credentials file.
+
+        Args:
+            credential (str): Credential to fetch.
+
+        Returns:
+            str or None: Resolved credential or ``None``.
+
+        """
+        return os.getenv(credential.upper()) \
+            or self._fetch_credential(credential)
+
+    def fetch_tokens(self, code=None, redirect_uri=None):
+        """Fetch tokens from token URL.
+
+        Args:
+            code (str): Authorization code. Defaults to ``None``.
+            redirect_uri (str): Redirect URI. Defaults to ``None``.
+
+        Returns:
+            dict: Response from token URL.
+
+        """
+        redirect_uri = redirect_uri or self.redirect_uri
+        c = self.get_credentials()
+        r = requests.post(
+            self.token_url,
+            data={
+                'client_id': c.client_id,
+                'client_secret': c.client_secret,
+                'code': code,
+                'redirect_uri': redirect_uri
+            },
+            auth=False
+        )
+        if not r.ok:
+            raise PanCloudError(
+                '%s %s: %s' % (r.status_code, r.reason, r.text)
+            )
+        try:
+            self.access_token_ = r.json().get(
+                'access_token', ''
+            )
+            self.refresh_token_ = r.json().get(
+                'refresh_token'
+            )
+            self.write_credentials()
+        except ValueError as e:
+            raise PanCloudError("Invalid JSON: %s" % e)
+        else:
+            if r.json().get('error_description') or r.json().get('error'):
+                raise PanCloudError(r.text)
+            return r.json()
+
+    def get_authorization_url(self, instance_id=None, redirect_uri=None,
+                              region=None, scope=None, state=None):
+        """Generate authorization URL.
+
+        Args:
+            instance_id (str): App Instance ID. Defaults to ``None``.
+            redirect_uri (str): Redirect URI. Defaults to ``None``.
+            region (str): App Region. Defaults to ``None``.
+            scope (str): Permissions. Defaults to ``None``.
+            state (str): UUID to detect CSRF. Defaults to ``None``.
+
+        Returns:
+            str, str: Auth URL, state
+
+        """
+        instance_id = instance_id or self.instance_id
+        redirect_uri = redirect_uri or self.redirect_uri
+        region = region or self.region
+        scope = scope or self.scope
+        state = state or self.state
+        c = self.get_credentials()
+        return requests.Request(
+            'GET',
+            self.auth_base_url,
+            params={
+                'client_id': c.client_id,
+                'instance_id': instance_id,
+                'redirect_uri': redirect_uri,
+                'region': region,
+                'response_type': 'code',
+                'scope': scope,
+                'state': state
+            }
+        ).prepare().url, state
+
+    def get_credentials(self):
+        """Get read-only credentials.
+
+        Returns:
+            class: Read-only credentials.
+
+        """
+        access_token = self.access_token_
+        client_id = self.client_id_ or self._resolve_credential(
+            'client_id')
+        client_secret = self.client_secret_ or self._resolve_credential(
+            'client_secret')
+        refresh_token = self.refresh_token_ or self._resolve_credential(
+            'refresh_token')
+        return ReadOnlyCredentials(
+            access_token, client_id, client_secret, refresh_token
+        )
+
+    def remove_profile(self, profile):
+        """Remove profile from credentials file.
+
+        Args:
+            profile (str): Credentials profile to remove.
+
+        Returns:
+            int: Result of operation.
+
+        """
+        with self.db_lock:
+            return self.db.remove(self.query.profile == profile)
+
+    def refresh(self, timeout=None, access_token=None):
+        """Refresh access token and renew refresh token.
+
+        Args:
+            timeout (int): HTTP timeout. Defaults to ``None``.
+            access_token (str): Access token to refresh. Defaults to ``None``.
+
+        Returns:
+            str: Refreshed access token.
+
+        """
+        if not self.token_lock.locked():
+            with self.token_lock:
+                if access_token == self.access_token_ or access_token is None:
+                    c = self.get_credentials()
+                    r = self.session.post(
+                        url=self.token_url,
+                        data={
+                            'client_id': c.client_id,
+                            'client_secret': c.client_secret,
+                            'refresh_token': c.refresh_token,
+                        },
+                        timeout=timeout
+                    )
+                    if not r.ok:
+                        raise PanCloudError(
+                            '%s %s: %s' % (r.status_code, r.reason, r.text)
+                        )
+                    try:
+                        self.access_token_ = r.json().get(
+                            'access_token', ''
+                        )
+                    except ValueError as e:
+                        raise PanCloudError("Invalid JSON: %s" % e)
+                    else:
+                        if r.json().get(
+                            'error_description'
+                        ) or r.json().get(
+                            'error'
+                        ):
+                            raise PanCloudError(r.text)
+                    return self.access_token_
+
+    def revoke_access_token(self, timeout=None):
+        """Revoke access token."""
+        c = self.get_credentials()
+        r = self.session.post(
+            url=self.token_revoke_url,
+            data={
+                'client_id': c.client_id,
+                'client_secret': c.client_secret,
+                'token': c.access_token,
+                'token_type_hint': 'access_token'
+            },
+            timeout=timeout
+        )
+        if not r.ok:
+            raise PanCloudError(
+                '%s %s: %s' % (r.status_code, r.reason, r.text)
+            )
+
+    def revoke_refresh_token(self, timeout=None):
+        """Revoke refresh token."""
+        c = self.get_credentials()
+        r = self.session.post(
+            url=self.token_revoke_url,
+            data={
+                'client_id': c.client_id,
+                'client_secret': c.client_secret,
+                'token': c.refresh_token,
+                'token_type_hint': 'refresh_token'
+            },
+            timeout=timeout
+        )
+        if not r.ok:
+            raise PanCloudError(
+                '%s %s: %s' % (r.status_code, r.reason, r.text)
+            )
+
+    def write_credentials(self):
+        """Write credentials.
+
+        Write credentials to credentials file. Performs ``upsert``.
+
+        Returns:
+            int: Result of operation.
+
+        """
+        c = self.get_credentials()
+        credentials = {
+            'profile': self.profile,
+            'client_id': self.client_id_ or c.client_id,
+            'client_secret': self.client_secret_ or c.client_secret,
+            'refresh_token': self.refresh_token_ or c.refresh_token
+        }
+        with self.db_lock:
+            return self.db.upsert(
+                credentials, self.query.profile == self.profile
+            )
+

--- a/pancloud/exceptions.py
+++ b/pancloud/exceptions.py
@@ -38,6 +38,21 @@ class HTTPError(PanCloudError):
         )
 
 
+class PartialCredentialsError(PanCloudError):
+    """The required credentials were not supplied."""
+
+    def __init__(self, inst):
+        """Convert exception instance to string.
+
+        Args:
+            inst (class): Exception instance.
+
+        """
+        PanCloudError.__init__(
+            self, "{}".format(inst)
+        )
+
+
 class RequiredKwargsError(PanCloudError):
     """A required keyword argument was not passed."""
 

--- a/pancloud/httpclient.py
+++ b/pancloud/httpclient.py
@@ -81,6 +81,8 @@ class HTTPClient(object):
             self.session.mount('http://', self.adapter)
 
             # Non-Requests key-word arguments
+            self.auto_refresh = kwargs.pop('auto_refresh', False)
+            self.credentials = kwargs.pop('credentials', None)
             self.enforce_json = kwargs.pop(
                 'enforce_json', False
             )
@@ -93,6 +95,11 @@ class HTTPClient(object):
             if len(kwargs) > 0:  # Handle invalid kwargs
                 raise UnexpectedKwargsError(kwargs)
 
+            if self.credentials:
+                self.session.headers = self._apply_credentials(
+                    self.session.headers, self.credentials
+                )
+
     def __repr__(self):
         for k in self.kwargs.get('headers', {}):
             if k.lower() == 'authorization':
@@ -101,6 +108,13 @@ class HTTPClient(object):
             self.__class__.__name__,
             ', '.join('%s=%r' % x for x in self.kwargs.items())
         )
+
+    def _apply_credentials(self, headers, credentials):
+        token = credentials.get_credentials().access_token
+        if token is None:
+            token = credentials.refresh(access_token=None, timeout=10)
+        headers['Authorization'] = "Bearer {}".format(token)
+        return headers
 
     def request(self, **kwargs):
         """Generate HTTP request using given parameters.
@@ -135,12 +149,21 @@ class HTTPClient(object):
         verify = kwargs.pop('verify', None)
 
         # Non-Requests key-word arguments
+        auto_refresh = kwargs.pop('auto_refresh', False)
+        credentials = kwargs.pop(
+            'credentials', None) or self.credentials
         enforce_json = kwargs.pop('enforce_json', self.enforce_json)
         path = kwargs.pop('path', '')  # default to empty path
         raise_for_status = kwargs.pop(
             'raise_for_status', self.raise_for_status
         )
         url = "{}:{}{}".format(url, self.port, path)
+
+        if credentials and not headers:
+            headers = self._apply_credentials(
+                self.session.headers, credentials)
+        elif credentials and headers:
+            headers = self._apply_credentials(headers, credentials)
 
         k = {  # Re-pack kwargs to dictionary
             'params': params or self.session.params,
@@ -189,6 +212,10 @@ class HTTPClient(object):
                         raise HTTPError(
                             "Invalid JSON: {}".format(e)
                         )
+            if credentials and auto_refresh:
+                if r.status_code == 401:
+                    token = credentials.get_credentials().access_token
+                    credentials.refresh(access_token=token, timeout=10)
             return r
         except requests.RequestException as e:
             raise HTTPError(e)

--- a/pancloud/httpclient.py
+++ b/pancloud/httpclient.py
@@ -117,7 +117,8 @@ class HTTPClient(object):
                 '%s=%r' % x for x in self.kwargs.items())
         )
 
-    def _apply_credentials(self, headers, credentials):
+    @staticmethod
+    def _apply_credentials(headers, credentials):
         token = credentials.get_credentials().access_token
         if token is None:
             token = credentials.refresh(access_token=None, timeout=10)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-pyopenssl
+tinydb

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements_dev.txt
+    -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
     py.test --basetemp={envtmpdir}


### PR DESCRIPTION
**Overview**

* Add OAuth2 support for performing token refresh and revocation
* Add support to HTTPClient for auto-refresh
* Add support for storing credentials in ~/.config/pancloud and as environment variables

**Implementation**

* Added `credentials` module that supports construction of `Credentials` object
* Added property methods for retrieving `access_token`, `client_id`, `client_secret`, and `refresh_token`.
* Add the following methods: `_fetch_credentia`, `get_credentials`, `remove_profile`, `refresh`, `write_credentials`.
* Using `TinyDB` library to `upsert` and store credentials in JSON format in ~/.config/pancloud directory.
* Added methods `revoke_access_token` and `revoke_refresh_token`. 
* Added `_resolve_credential` method which looks for credential in 1) ENVIRON, 2) Credentials file.
* Added `region`, `redirect_uri` and `auth_base_url` variables/attributes.
* Added method `get_authorization_url` for generating authorization URL and returning state.
* Integrated Credentials with HTTPClient to support `auto_refresh` and automatic application of `access_token` to `Authorization: Bearer` header.