### PR TITLE
#21 Hotfix 1.0.4

### DIFF
--- a/pancloud/httpclient.py
+++ b/pancloud/httpclient.py
@@ -11,7 +11,7 @@ import requests
 from requests.adapters import HTTPAdapter
 
 from .exceptions import UnexpectedKwargsError, \
-    RequiredKwargsError, HTTPError
+    RequiredKwargsError, HTTPError, PanCloudError
 
 
 class HTTPClient(object):
@@ -194,7 +194,7 @@ class HTTPClient(object):
                     try:
                         r.json()
                     except ValueError as e:
-                        raise HTTPError(
+                        raise PanCloudError(
                             "Invalid JSON: {}".format(e)
                         )
             return r

--- a/pancloud/logging.py
+++ b/pancloud/logging.py
@@ -169,48 +169,6 @@ class LoggingService(object):
         )
         return r
 
-    def poll_all(self, query_id=None, sequence_no=None, params=None,
-                 **kwargs):  # pragma: no cover
-        """Retrieve pages iteratively in a greedy manner.
-
-        Automatically increments the sequenceNo as it continues to poll
-        for results until the endpoint reports ``JOB_FINISHED`` or
-        ``JOB_FAILED``, or an exception is raised by the pancloud library.
-
-        WARNING: Be mindful of memory consumption as all results will be
-        stored in memory until they are destroyed or garbage collection
-        occurs.
-
-        Args:
-            params (dict): Payload/request dictionary.
-            query_id (str): Specifies the ID of the query job.
-            sequence_no (int): Specifies the sequenceNo.
-            **kwargs: Supported :meth:`~pancloud.httpclient.HTTPClient.request` parameters.
-
-        Returns:
-            list of requests.Response: Requests Response() objects.
-
-        Examples:
-            Refer to ``logging_query.py`` example.
-
-        """
-        pages = []
-        while True:
-            r = self.poll(query_id, sequence_no, params, **kwargs)
-            if r.json()['queryStatus'] == "FINISHED":
-                params['sequenceNo'] += 1
-                pages.append(r)
-            elif r.json()['queryStatus'] == "JOB_FINISHED":
-                pages.append(r)
-                break
-            elif r.json()['queryStatus'] == "JOB_FAILED":
-                pages.append(r)
-                break
-            else:  # query status ostensibly == 'RUNNING'
-                pages.append(r)
-                time.sleep(1)  # wait before trying again
-        return pages
-
     def query(self, data=None, **kwargs):  # pragma: no cover
         """Generate a query that retrieves log records.
 

--- a/pancloud/logging.py
+++ b/pancloud/logging.py
@@ -118,7 +118,10 @@ class LoggingService(object):
                 **kwargs
             )
             if r.json()['queryStatus'] == "FINISHED":
-                sequence_no += 1
+                if sequence_no is not None:
+                    sequence_no += 1
+                else:
+                    sequence_no = 1
                 yield r
             elif r.json()['queryStatus'] == "JOB_FINISHED":
                 yield r

--- a/tests/test_httpclient.py
+++ b/tests/test_httpclient.py
@@ -13,7 +13,7 @@ sys.path[:0] = [os.path.join(curpath, os.pardir)]
 
 from pancloud.httpclient import HTTPClient
 from pancloud.exceptions import HTTPError, RequiredKwargsError, \
-    UnexpectedKwargsError
+    UnexpectedKwargsError, PanCloudError
 
 
 HTTPBIN = os.environ.get('HTTPBIN_URL', 'http://httpbin.org')
@@ -57,7 +57,7 @@ class TestHTTPClient:
             HTTPClient(url=TARPIT).request(method='GET', foo='foo')
 
     def test_enforce_json(self):
-        with pytest.raises(HTTPError):
+        with pytest.raises(PanCloudError):
             HTTPClient(
                 url=HTTPBIN,
                 port=80,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -32,7 +32,6 @@ class TestLoggingService:
         LoggingService(url=TARPIT).query
         LoggingService(url=TARPIT).delete
         LoggingService(url=TARPIT).iter_poll
-        LoggingService(url=TARPIT).poll_all
         LoggingService(url=TARPIT).xpoll
 
     def test_required_kwargs(self):


### PR DESCRIPTION
**Changes**

* Improved loop control for `iter_poll` method by explicitly checking for `queryStatus` `RUNNING` and raising `PanCloudError` for unexpected `queryStatus`.
* Removed references to `params['sequenceNo']` and replaced with `sequence_no` where applicable.
* Retired and removed `poll_all` method (see Issue #21 for more details).
* Raise `PanCloudError` for `enforce_json` error instead of `HTTPError`.
