### PR TITLE
Hotfix 1.0.5

### DIFF
--- a/examples/credentials_generate.py
+++ b/examples/credentials_generate.py
@@ -21,10 +21,12 @@ def main():
         client_id = input("CLIENT_ID: ")
         client_secret = getpass.getpass(prompt="CLIENT_SECRET: ")
         refresh_token = getpass.getpass(prompt="REFRESH_TOKEN: ")
+        profile = input("PROFILE [default]: ") or None
         print("Generating credentials file...")
         c = Credentials(client_id=client_id,
                         client_secret=client_secret,
-                        refresh_token=refresh_token)
+                        refresh_token=refresh_token,
+                        profile=profile)
         c.write_credentials()
         print("Done!\n")
     except KeyboardInterrupt:

--- a/pancloud/credentials.py
+++ b/pancloud/credentials.py
@@ -357,8 +357,6 @@ class Credentials(object):
             int: Result of operation.
 
         """
-        if not os.path.exists(directory):
-            os.makedirs(directory)
         c = self.get_credentials()
         credentials = {
             'profile': self.profile,


### PR DESCRIPTION
* Remove erroneous reference to `directory` in `write_credentials()` method.
* Add prompt for `profile` to `credentials_generate.py` script which defaults to `None`.