### PR TITLE
Set permissions on creation of credentials file

### DIFF
--- a/pancloud/credentials.py
+++ b/pancloud/credentials.py
@@ -79,12 +79,11 @@ class Credentials(object):
         self.token_lock = Lock()
         self.token_url = token_url or TOKEN_URL
         self.token_revoke_url = token_revoke_url or REVOKE_URL
-        if not os.path.exists(os.path.join(
-            os.path.expanduser('~'), '.config')
-        ):
-            os.mkdir(os.path.join(os.path.expanduser('~'), '.config'))
         if not os.path.exists(os.path.dirname(self.path)):
-            os.mkdir(os.path.dirname(self.path))
+            try:
+                os.makedirs(os.path.dirname(self.path), 0o700)
+            except OSError as e:
+                raise PanCloudError("{}".format(e))
         self.db = TinyDB(self.path, sort_keys=True, indent=4,
                          default_table='profiles')
         self.query = Query()


### PR DESCRIPTION
* Change from `os.mkdir()` to `os.makedirs()` to recursively build credentials path
* Set permissions to `0700` on creation of folders and `credentials.json` file.