### PR TITLE
Change logging xpoll() to return entire log entry instead of just

### DIFF
--- a/pancloud/logging.py
+++ b/pancloud/logging.py
@@ -269,7 +269,7 @@ class LoggingService(object):
 
             self._debug('hits: %d', len(hits))
             for x in hits:
-                yield x['_source']
+                yield x
 
             if r_json['queryStatus'] == 'JOB_FINISHED':
                 if delete_query:


### PR DESCRIPTION
"_source" dictionary.  This includes additional fields including
"_id".

NOTE: this breaks backwards compatibility for the response JSON
object.