### PR TITLE
For logging --query request, if the response contains a queryId and

### DIFF
--- a/bin/summit.py
+++ b/bin/summit.py
@@ -160,8 +160,11 @@ def logging(options, session):
             sys.exit(1)
 
         print_status(action, r, options)
-        print_response(r, options)
+        json_ = print_response(r, options)
         exit_for_http_status(r)
+
+        if json_ is not None and options['id'] is None and 'queryId' in json_:
+            options['id'] = json_['queryId']
 
     def poll(api, options):
         action = inspect.stack()[0][3]
@@ -575,6 +578,7 @@ def print_response(r, options):
             sys.exit(1)
 
         print_response_body(options, obj)
+        return obj
     else:
         print('WARNING: Response Content-Type:', x, file=sys.stderr)
 
@@ -807,7 +811,7 @@ def parse_opts():
         'id=', 'seq=',
         'set', 'get', 'ack', 'nack', 'follow',
         'count', 'domains', 'attributes',
-        'R0=', 'R1=', 'R2=', 'R3=',
+        'R0=', 'R1=', 'R2=',
         'debug=', 'version', 'help',
     ]
 


### PR DESCRIPTION
--id is not specified, set --id to queryId.  This allows --poll,
--xpoll and --delete to use queryId from the query.

For example, the following perfroms a query, then a poll (with default
sequenceNo 0), then a delete:

$ summit.py -CH --R0 init.json -L --query --R1 '{"query":"select * from panw.system limit 2"}' \
> --start 1526133872 --end 1526136834 --poll --delete
query: 200 OK 239 queryStatus=RUNNING queryId=9b7b20cf-3d20-47ed-9cd9-5bb7c2f9077a sequenceNo=0
poll: 200 OK 1733 queryStatus=JOB_FINISHED queryId=9b7b20cf-3d20-47ed-9cd9-5bb7c2f9077a sequenceNo=0 size=2
delete: 200 OK 16