### PR TITLE
Add support for writing logs to Logging Service

### DIFF
--- a/examples/logging_write.py
+++ b/examples/logging_write.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Logging Service example using write."""
+
+import os
+import sys
+
+curpath = os.path.dirname(os.path.abspath(__file__))
+sys.path[:0] = [os.path.join(curpath, os.pardir)]
+
+from pancloud import LoggingService
+from pancloud import Credentials
+
+
+VENDOR_ID = 'panw'
+LOG_TYPE = 'threat'
+
+url = 'https://apigw-stg4.us.paloaltonetworks.com'
+
+c = Credentials()
+
+# Create Logging Service instance
+ls = LoggingService(
+    url=url,
+    credentials=c
+)
+
+data = [
+    {
+        'generatedTime': 0,
+        'uuid': 1,
+        'user': 'acme/wcoyote',
+        'action': 'drop',
+        'type': 'vulnerability',
+        'subType': 'brute-force',
+        'name': 'anvil',
+        'repeatCnt': 5
+    }
+]
+
+q = ls.write(vendor_id=VENDOR_ID, log_type=LOG_TYPE, data=data)
+
+print(
+    "\nWRITE: {}\n".format(q.text)
+)

--- a/pancloud/httpclient.py
+++ b/pancloud/httpclient.py
@@ -235,7 +235,7 @@ class HTTPClient(object):
                   'timeout']:
             if x in kwargs and x == 'data':
                 d = kwargs.pop(x)
-                if type(d) is dict:
+                if type(d) is dict or type(d) is list:
                     k[x] = json.dumps(d)  # convert to str
                 else:  # let requests handle the form-encoding
                     k[x] = d

--- a/pancloud/logging.py
+++ b/pancloud/logging.py
@@ -300,3 +300,37 @@ class LoggingService(object):
         for x in self.xpoll(query_id, sequence_no, params, delete_query,
                             **kwargs):
             yield x
+
+    def write(self, vendor_id=None, log_type=None, data=None, **kwargs):
+        """Write log records to the Logging Service.
+
+        This API requires a JSON array in its request body, each element
+        of which represents a single log record. Log records are
+        provided as JSON objects. Every log record must include the
+        primary timestamp field that you identified when you registered
+        your app. Every log record must also identify the log type.
+
+        Args:
+            vendor_id (str): Vendor ID.
+            log_type (str): Log type.
+            data (dict): Payload/request dictionary.
+            **kwargs: Supported :meth:`~pancloud.httpclient.HTTPClient.request` parameters.
+
+        Returns:
+            requests.Response: Requests Response() object.
+
+        Examples:
+            Refer to ``logging_write.py`` example.
+
+        """
+        path = "/logging-service/v1/logs/{}/{}".format(
+            vendor_id, log_type
+        )
+        r = self._httpclient.request(
+            method="POST",
+            url=self.url,
+            data=data,
+            path=path,
+            **kwargs
+        )
+        return r


### PR DESCRIPTION
* Added `write()` method to Logging Service class
* Updated `HTTPClient.request()` method to support passing list of log dictionaries in data payload 
* Added `logging_write.py` to examples library 