### PR TITLE
Add support for caching access tokens

### DIFF
--- a/pancloud/adapters/adapter.py
+++ b/pancloud/adapters/adapter.py
@@ -45,12 +45,14 @@ class StorageAdapter(ABC):  # enforce StorageAdapter interface
         pass
 
     @abstractmethod
-    def write_credentials(self, credentials=None, profile=None):
+    def write_credentials(self, credentials=None, profile=None,
+                          cache_token=None):
         """Write credentials.
 
         Write credentials to store.
 
         Args:
+            cache_token (bool): If ``True``, stores ``access_token`` in token store. Defaults to ``True``.
             credentials (class): Read-only credentials.
             profile (str): Credentials profile. Defaults to ``'default'``.
 

--- a/pancloud/adapters/tinydb_adapter.py
+++ b/pancloud/adapters/tinydb_adapter.py
@@ -64,12 +64,14 @@ class TinyDBStore(StorageAdapter):
         with self.db:
             return self.db.remove(self.query.profile == profile)
 
-    def write_credentials(self, credentials=None, profile=None):
+    def write_credentials(self, credentials=None, profile=None,
+                          cache_token=None):
         """Write credentials.
 
         Write credentials to credentials file. Performs ``upsert``.
 
         Args:
+            cache_token (bool): If ``True``, stores ``access_token`` in token store. Defaults to ``True``.
             credentials (class): Read-only credentials.
             profile (str): Credentials profile. Defaults to ``'default'``.
 
@@ -83,6 +85,8 @@ class TinyDBStore(StorageAdapter):
             'client_secret': credentials.client_secret,
             'refresh_token': credentials.refresh_token
         }
+        if cache_token:
+            d.update({'access_token': credentials.access_token})
         with self.lock:
             return self.db.upsert(
                 d, self.query.profile == profile

--- a/pancloud/credentials.py
+++ b/pancloud/credentials.py
@@ -28,11 +28,11 @@ ReadOnlyCredentials = namedtuple(
 class Credentials(object):
     """An Application Framework credentials object."""
 
-    def __init__(self, auth_base_url=None, client_id=None, client_secret=None,
-                 instance_id=None, profile=None, redirect_uri=None,
-                 region=None, refresh_token=None, scope=None,
-                 storage_adapter=None, token_url=None, token_revoke_url=None,
-                 **kwargs):
+    def __init__(self, auth_base_url=None, cache_token=True,
+                 client_id=None, client_secret=None, instance_id=None,
+                 profile=None, redirect_uri=None, region=None,
+                 refresh_token=None, scope=None, storage_adapter=None,
+                 token_url=None, token_revoke_url=None, **kwargs):
         """Persist Session() and credentials attributes.
 
         Built on top of the ``Requests`` library, ``Credentials`` is an
@@ -65,6 +65,7 @@ class Credentials(object):
         """
         self.access_token_ = None
         self.auth_base_url = auth_base_url or BASE_URL
+        self.cache_token_ = cache_token
         self.client_id_ = client_id
         self.client_secret_ = client_secret
         self.environ = os.environ
@@ -105,6 +106,10 @@ class Credentials(object):
     def access_token(self):
         """Get access_token"""
         return self.access_token_
+
+    @property
+    def cache_token(self):
+        return self.cache_token_
 
     @property
     def client_id(self):
@@ -239,7 +244,11 @@ class Credentials(object):
             class: Read-only credentials.
 
         """
-        access_token = self.access_token_
+        if self.cache_token:
+            access_token = self._resolve_credential(
+                'access_token') or self.access_token_
+        else:
+            access_token = self.access_token_
         client_id = self.client_id_ or self._resolve_credential(
             'client_id')
         client_secret = self.client_secret_ or self._resolve_credential(
@@ -358,5 +367,6 @@ class Credentials(object):
         """
         c = self.get_credentials()
         return self.storage().write_credentials(
-            credentials=c, profile=self.profile
+            credentials=c, profile=self.profile,
+            cache_token=self.cache_token_
         )

--- a/pancloud/httpclient.py
+++ b/pancloud/httpclient.py
@@ -253,6 +253,11 @@ class HTTPClient(object):
 
         # Prepare and send the Request() and return Response()
         try:
+            if credentials:
+                if credentials.cache_token:
+                    h = self._apply_credentials(
+                        k['headers'], credentials)
+                    k['headers'] = h
             r = self._send_request(
                 enforce_json, method, raise_for_status, url, **k
             )


### PR DESCRIPTION
* Add support for caching access tokens (enabled by default)
* Update `HTTPClient.request()` to support token caching