### PR TITLE
Add support for custom read/write credentials path #87

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ python:
 - 2.7
 script:
 - tox
-- coverage run --source pancloud -m py.test
+- coverage run --source pancloud -m py.test --ignore=examples
 - coverage report -m
 
 # safelist


### PR DESCRIPTION
**Usage**

```
from pancloud import Credentials

c = Credentials(path='foo')
c.get_credentials()
```
After running the code above the expectation is the `credentials.json()` file will be read/written from the relative `foo` directory.

```
from pancloud import Credentials

c = Credentials(path='/opt/pancloud/foo')
c.get_credentials()
```
After running the code above the expectation is the `credentials.json()` file will be read/written from the absolute `/opt/pancloud/foo` directory.