### PR TITLE
Httpclient refactor

### DIFF
--- a/pancloud/httpclient.py
+++ b/pancloud/httpclient.py
@@ -80,7 +80,6 @@ class HTTPClient(object):
 
             # Non-Requests key-word arguments
             self.auto_refresh = kwargs.pop('auto_refresh', True)
-            self.auto_retry = kwargs.pop('auto_retry', True)
             self.credentials = kwargs.pop('credentials', None)
             self.enforce_json = kwargs.pop(
                 'enforce_json', False
@@ -121,7 +120,7 @@ class HTTPClient(object):
         )
 
     @staticmethod
-    def _apply_credentials(auto_refresh=None, credentials=None,
+    def _apply_credentials(auto_refresh=True, credentials=None,
                            headers=None):
         """Update Authorization header.
 
@@ -209,22 +208,21 @@ class HTTPClient(object):
             requests.Response: Requests Response() object
 
         """
-        url = kwargs.pop('url', None) or self.url
+        url = kwargs.pop('url', self.url)
 
         # Session() overrides
-        auth = kwargs.pop('auth', None)
-        cert = kwargs.pop('cert', None)
-        cookies = kwargs.pop('cookies', None)
-        headers = kwargs.pop('headers', None)
-        params = kwargs.pop('params', None)
-        proxies = kwargs.pop('proxies', None)
-        stream = kwargs.pop('stream', None)
-        verify = kwargs.pop('verify', None)
+        auth = kwargs.pop('auth', self.session.auth)
+        cert = kwargs.pop('cert', self.session.cert)
+        cookies = kwargs.pop('cookies', self.session.cookies)
+        headers = kwargs.pop('headers', self.session.headers.copy())
+        params = kwargs.pop('params', self.session.params)
+        proxies = kwargs.pop('proxies', self.session.proxies)
+        stream = kwargs.pop('stream', self.session.stream)
+        verify = kwargs.pop('verify', self.session.verify)
 
         # Non-Requests key-word arguments
         auto_refresh = kwargs.pop('auto_refresh', self.auto_refresh)
-        auto_retry = kwargs.pop('auto_retry', self.auto_retry)
-        credentials = kwargs.pop('credentials', None)
+        credentials = kwargs.pop('credentials', self.credentials)
         enforce_json = kwargs.pop('enforce_json', self.enforce_json)
         path = kwargs.pop('path', '')  # default to empty path
         raise_for_status = kwargs.pop(
@@ -233,21 +231,21 @@ class HTTPClient(object):
         url = "{}:{}{}".format(url, self.port, path)
 
         if credentials:
-            if headers is None:
-                headers = self.session.headers.copy()
-            self._apply_credentials(credentials, headers)
-        else:
-            credentials = self.credentials
+            self._apply_credentials(
+                auto_refresh=auto_refresh,
+                credentials=credentials,
+                headers=headers
+            )
 
         k = {  # Re-pack kwargs to dictionary
-            'params': params or self.session.params,
-            'headers': headers or self.session.headers,
-            'cookies': cookies or self.session.cookies,
-            'auth': auth or self.session.auth,
-            'proxies': proxies or self.session.proxies,
-            'verify': verify or self.session.verify,
-            'stream': stream or self.session.stream,
-            'cert': cert or self.session.cert
+            'params': params,
+            'headers': headers,
+            'cookies': cookies,
+            'auth': auth,
+            'proxies': proxies,
+            'verify': verify,
+            'stream': stream,
+            'cert': cert
         }
 
         # Request() overrides
@@ -270,21 +268,6 @@ class HTTPClient(object):
             r = self._send_request(
                 enforce_json, method, raise_for_status, url, **k
             )
-            # TODO remove the following if statement
-            if r.status_code == 401:
-                if credentials and auto_refresh:
-                    token = credentials.get_credentials().access_token
-                    credentials.refresh(access_token=token, timeout=10)
-                    self._apply_credentials(
-                        auto_refresh=auto_refresh,
-                        credentials=credentials,
-                        headers=headers or self.session.headers
-                    )
-                    if auto_retry:
-                        r = self._send_request(
-                            enforce_json, method, raise_for_status, url,
-                            **k
-                        )
             return r
         except requests.RequestException as e:
             raise HTTPError(e)

--- a/pancloud/httpclient.py
+++ b/pancloud/httpclient.py
@@ -98,7 +98,10 @@ class HTTPClient(object):
 
             if self.credentials:
                 self._apply_credentials(
-                    self.credentials, self.session.headers)
+                    auto_refresh=self.auto_refresh,
+                    credentials=self.credentials,
+                    headers=self.session.headers
+                )
 
     def __repr__(self):
         for k in self.kwargs.get('headers', {}):
@@ -118,22 +121,26 @@ class HTTPClient(object):
         )
 
     @staticmethod
-    def _apply_credentials(credentials, headers):
+    def _apply_credentials(auto_refresh=None, credentials=None,
+                           headers=None):
         """Update Authorization header.
 
         Update request headers with latest `access_token`. Perform token
         `refresh` if token is ``None``.
 
         Args:
+            auto_refresh (bool): Perform token refresh if access_token is ``None`` or expired. Defaults to ``True``.
             credentials (class): Read-only credentials.
             headers (class): Requests `CaseInsensitiveDict`.
 
         """
         token = credentials.get_credentials().access_token
-        if token is None:
-            token = credentials.refresh(access_token=None, timeout=10)
-        elif credentials.jwt_is_expired():
-            token = credentials.refresh(timeout=10)
+        if auto_refresh is True:
+            if token is None:
+                token = credentials.refresh(
+                    access_token=None, timeout=10)
+            elif credentials.jwt_is_expired():
+                token = credentials.refresh(timeout=10)
         headers.update(
             {'Authorization': "Bearer {}".format(token)}
         )
@@ -263,12 +270,15 @@ class HTTPClient(object):
             r = self._send_request(
                 enforce_json, method, raise_for_status, url, **k
             )
+            # TODO remove the following if statement
             if r.status_code == 401:
                 if credentials and auto_refresh:
                     token = credentials.get_credentials().access_token
                     credentials.refresh(access_token=token, timeout=10)
                     self._apply_credentials(
-                        credentials, headers or self.session.headers
+                        auto_refresh=auto_refresh,
+                        credentials=credentials,
+                        headers=headers or self.session.headers
                     )
                     if auto_retry:
                         r = self._send_request(


### PR DESCRIPTION
* Removed `auto_retry` kwarg as it no longer fits in the API.
* Refactored how `request()`-level kwargs are chosen over `Session()`-level kwargs to improve readability.
* Removed `if` statement block that handled HTTP `401` responses from server since `_apply_credentials()` now checks for expiration. In theory, assuming valid credentials are present, there should not be a case where `pancloud` sends an invalid `access_token` to a protected endpoint.