### PR TITLE
b64decode returns a bytes object in python3 instead of a string

### DIFF
--- a/pancloud/credentials.py
+++ b/pancloud/credentials.py
@@ -244,7 +244,7 @@ class Credentials(object):
             if rem > 0:  # add padding
                 payload += '=' * (4 - rem)
             try:
-                decoded_jwt = b64decode(payload)
+                decoded_jwt = b64decode(payload).decode("utf-8")
             except TypeError as e:
                 raise PanCloudError(
                     "Failed to base64 decode JWT: %s" % e)


### PR DESCRIPTION
A bytes object can't be used as input to json.load(). The fix works on both python3 and python2.